### PR TITLE
Hidden attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,34 +8,35 @@ This page demonstrates how to make a modal window as accessible as possible to a
 * There is now a check that when the modal window is open, detects any time the #mainPage or any of its contents receives focus and will redirect the focus to the modal window. This was necessary because of the modal window was open and you went to the address bar, if you started tabbing again you would interact with the main page.
 * Both the documentation and the [live demo](http://gdkraus.github.io/accessible-modal-dialog/) now live on GitHub.
 
-##Features
+## Features
 
 This example implements the following features:
 
 1. The page is divided into three sections:
-  1. <div id="mainPage></div>
-  2. <div id="modal" role="dialog"></div>
-  3. <div id="modalOverlay"></div>
+    1. `<div id="mainPage></div>`
+    2. `<div id="modal" role="dialog"></div>`
+    3. `<div id="modalOverlay"></div>`
 2. When the modal dialog is displayed, an overlay is placed over top of the mainPage so it is
-  1. visually grayed out in order to indicate you cannot interact with what is behind the window
-  2. not clickable with the mouse
-3. When the modal dialog is displayed, the mainPage is marked with aria-hidden="true" to prevent screen readers from interacting with it once the modal dialog is open. Additionally, the mainPage gets an even listener for any time it or any of its children receive focus. When they do receive focus, the user's focus is redirected to the modal window.
+    * visually grayed out in order to indicate you cannot interact with what is behind the window
+    * not clickable with the mouse
+3. When the modal dialog is displayed, the mainPage is marked with `aria-hidden="true"` to prevent screen readers from interacting with it once the modal dialog is open. Additionally, the mainPage gets an even listener for any time it or any of its children receive focus. When they do receive focus, the user's focus is redirected to the modal window.
 4. Keyboard access is limited to only interacting with the modal dialog once it is visible
-  1. The tab key loops through all of the keyboard focusable items within the modal window
-  2. This is determined programmatically through the DOM each time the tab key is pressed so you do not have to create an explicit list of focusable items within the modal window to keep track of
-  3. The escape key is mapped to the function to close the modal window
-  4. The enter key is mapped to the submit function of the modal window
-5. The title of the modal dialog is identified through the aria-labelledby attribute.
-6. The beginning of the modal dialog is marked with an h1
+    * The tab key loops through all of the keyboard focusable items within the modal window
+    * This is determined programmatically through the DOM each time the tab key is pressed so you do not have to create an explicit list of focusable items within the modal window to keep track of
+    * The escape key is mapped to the function to close the modal window
+    * The enter key is mapped to the submit function of the modal window
+5. The title of the modal dialog is identified through the `aria-labelledby` attribute.
+6. The beginning of the modal dialog is marked with an `h1`
 7. There are offscreen instructions that describe the modal dialog and how to interact with it
-  1. The instructions are attached through the aria-describedby attribute.
-  2. Only NVDA and ChromeVox automatically announce the aria-described by contents
-8. The contents of the modal are wrapped in role="document". This is to aid NVDA users so they can more easily browse the contents of the modal. NVDA previously added support for fully browsing the contents of the modal, but it requires the user to switch browsing modes in NVDA. Using role="document" automatically puts the user in the mode where they can fully browse the contents.
-  1. role="document" is optional and the modal window is still fully functional to all users even when this attribute is left off.
+    * The instructions are attached through the `aria-describedby` attribute.
+    * Only NVDA and ChromeVox automatically announce the `aria-describedby` contents
+8. The contents of the modal are wrapped in `role="document"`. 
+    * This is to aid NVDA users so they can more easily browse the contents of the modal. NVDA previously added support for fully browsing the contents of the modal, but it requires the user to switch browsing modes in NVDA. Using `role="document"` automatically puts the user in the mode where they can fully browse the contents.
+    * `role="document"` is optional and the modal window is still fully functional to all users even when this attribute is left off.
 9. Configurations Tested
-  1. JAWS 16.0.1925 in IE 11.0.9600.18036 in Windows 8.1: Passed - although aria-describedby is not read automatically
-  2. NVDA 2015.3 in Firefox 40.0.3 in Windows 8.1: Passed
-  3. Window Eyes 9.2.1.0 in 11.0.9600.18036 in Windows 8.1: Passed - although the title of the modal window and the aria-describedby is not read automatically
-  4. VoiceOver in Safari 8.0.8 (9537.71) in OS X 10.10.5: Passed - although aria-describedby is not read automatically
-  5. ChromeVox 45.0.2428.0 in Chrome 45.0.2454.101 in OS X 10.10.5: Passed
-  6. Orca 3.10.3 in Firefox 39.0 in Ubuntu 14.04: Partial Functionality - does not support aria-hidden and does not announce the aria-describedby
+    1. JAWS 16.0.1925 in IE 11.0.9600.18036 in Windows 8.1: Passed - although aria-describedby is not read automatically
+    2. NVDA 2015.3 in Firefox 40.0.3 in Windows 8.1: Passed
+    3. Window Eyes 9.2.1.0 in 11.0.9600.18036 in Windows 8.1: Passed - although the title of the modal window and the aria-describedby is not read automatically
+    4. VoiceOver in Safari 8.0.8 (9537.71) in OS X 10.10.5: Passed - although aria-describedby is not read automatically
+    5. ChromeVox 45.0.2428.0 in Chrome 45.0.2454.101 in OS X 10.10.5: Passed
+    6. Orca 3.10.3 in Firefox 39.0 in Ubuntu 14.04: Partial Functionality - does not support aria-hidden and does not announce the aria-describedby

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
        </form>
    </div>
 </div>
-<div id="modalOverlay" tabindex="-1"></div>
+<div id="modalOverlay" hidden tabindex="-1"></div>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <h2>The Accessible Modal Window in Action</h2>
         <p>To see this in action, you just need to <button id="startModal">view the modal window</button>. If the modal window works as planned, once the modal window is visible you should not be able to interact with other links on the main page like <a href="https://github.com/">going to the main GitHub page</a>. If you can interact with the page behind the modal window, guidance is given for how to get back to the modal window.</p>
     </div>
-    <div id="modal" aria-hidden="true" aria-labelledby="modalTitle" aria-describedby="modalDescription" role="dialog">
+    <div id="modal" hidden aria-labelledby="modalTitle" aria-describedby="modalDescription" role="dialog">
         <div role="document">
          <div id="modalDescription" class="screen-reader-offscreen">Beginning of dialog window. It begins with a heading 1 called &quot;Registration Form&quot;. Escape will cancel and close the window. This form does not collect any actual information.</div>
          <h1 id="modalTitle">Registration Form</h1>

--- a/modal-window.css
+++ b/modal-window.css
@@ -7,7 +7,6 @@
 	position:fixed;
 	top:0;
 	left:0;
-	display:none;
 	margin:0;
 	padding:0;
 }

--- a/modal-window.css
+++ b/modal-window.css
@@ -23,7 +23,6 @@
 	position:fixed;
 	top:25%;
 	left:25%;
-	display:none;
 }
 #modal h1 {
 	text-align:center;
@@ -46,4 +45,8 @@
 	width:1px;
 	height:1px;
 	top:auto;
+}
+
+[hidden] {
+	display:none;
 }

--- a/modal-window.js
+++ b/modal-window.js
@@ -155,7 +155,7 @@ function setFocusToFirstItemInModal(obj){
 
 function showModal(obj) {
     jQuery('#mainPage').attr('aria-hidden', 'true'); // mark the main page as hidden
-    jQuery('#modalOverlay').css('display', 'block'); // insert an overlay to prevent clicking and make a visual change to indicate the main apge is not available
+    jQuery('#modalOverlay').prop('hidden', false); // insert an overlay to prevent clicking and make a visual change to indicate the main apge is not available
     jQuery('#modal').prop('hidden', false); // make the modal window visible
 
     // attach a listener to redirect the tab to the modal window if the user somehow gets out of the modal window
@@ -170,7 +170,7 @@ function showModal(obj) {
 }
 
 function hideModal() {
-    jQuery('#modalOverlay').css('display', 'none'); // remove the overlay in order to make the main screen available again
+    jQuery('#modalOverlay').prop('hidden', true);; // remove the overlay in order to make the main screen available again
     jQuery('#modal').prop('hidden', true); // hide the modal window
     jQuery('#mainPage').attr('aria-hidden', 'false'); // mark the main page as visible
 

--- a/modal-window.js
+++ b/modal-window.js
@@ -156,8 +156,7 @@ function setFocusToFirstItemInModal(obj){
 function showModal(obj) {
     jQuery('#mainPage').attr('aria-hidden', 'true'); // mark the main page as hidden
     jQuery('#modalOverlay').css('display', 'block'); // insert an overlay to prevent clicking and make a visual change to indicate the main apge is not available
-    jQuery('#modal').css('display', 'block'); // make the modal window visible
-    jQuery('#modal').attr('aria-hidden', 'false'); // mark the modal window as visible
+    jQuery('#modal').prop('hidden', false); // make the modal window visible
 
     // attach a listener to redirect the tab to the modal window if the user somehow gets out of the modal window
     jQuery('body').on('focusin','#mainPage',function() {
@@ -172,8 +171,7 @@ function showModal(obj) {
 
 function hideModal() {
     jQuery('#modalOverlay').css('display', 'none'); // remove the overlay in order to make the main screen available again
-    jQuery('#modal').css('display', 'none'); // hide the modal window
-    jQuery('#modal').attr('aria-hidden', 'true'); // mark the modal window as hidden
+    jQuery('#modal').prop('hidden', true); // hide the modal window
     jQuery('#mainPage').attr('aria-hidden', 'false'); // mark the main page as visible
 
     // remove the listener which redirects tab keys in the main content area to the modal


### PR DESCRIPTION
Using `hidden` attribute for modal and modal overlay, instead of managing `display` and `aria-hidden` separately. 